### PR TITLE
Changed page layout creation to use only KOMA-Script tools

### DIFF
--- a/content/Appendix.tex
+++ b/content/Appendix.tex
@@ -5,4 +5,4 @@ This appendix presents the details of the stationary analysis and multi-trajecto
 
 
 \section*{Interconnected Model Analysis Output}
-\VerbatimInput[label=\fbox{\color{black}Interconnected Model Analysis Output}]{Sourcecode/Output_Analysis_Interconected.txt}
+\VerbatimInput[label=\fbox{\color{black}Interconnected Model Analysis Output}]{sourcecode/Output_Analysis_Interconected.txt}

--- a/content/Thesis_2_Background.tex
+++ b/content/Thesis_2_Background.tex
@@ -33,4 +33,4 @@ In the example presented in Figure~\ref{fig:Simple Markov Chain Model} the trans
 \section{Monte Carlo Simulation Algorithm} 
 A Monte Carlo simulation algorithm follows a standard Monte Carlo method \cite{montecalro}. Whenever a decision needs to be made, a random result is generated based on the probability of each of the possible choices. Considering a Markov chain as the underlying model for a simulation executing a Monte Carlo algorithm, given the current state there are some outgoing transitions, each of them with a probability of being executed next...
 
-\input{SourceCode/Algorithm_Monte_Carlo}
+\input{sourcecode/Algorithm_Monte_Carlo}

--- a/content/Thesis_5_Results.tex
+++ b/content/Thesis_5_Results.tex
@@ -7,4 +7,4 @@ In this chapter an analysis and evaluation of the TimeNET implementation of the 
 \section{Multi-Trajectory Results}
 In this section the results from the multi-trajectory simulations are compared with the results from the previous work. The multi-trajectory algorithm has been executed with the default parameters over all variations of the models, but only the most significant results are presented here. 
 
-\input{SourceCode/Tables_Comparative_Results}
+\input{sourcecode/Tables_Comparative_Results}

--- a/header.tex
+++ b/header.tex
@@ -18,13 +18,15 @@
 		bibliography=totoc,			% list bibliography in the table of contents
 		captions=tableheading,		% output labeling tables below
 		draft=true, 				% draft=true useful during writing, set to false for final document %BUG will stop hyperref from working (bookmarks)
+                DIV=13,					%number columns for page layout calculation. The larger, the smaller margins will be. Standard for 12pt is 12
+                BCOR=10mm,				%reserved inner margin for binding
 ]{scrreprt}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %% Line Spacing and Margins %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage[onehalfspacing]{setspace}
-\usepackage{geometry}
+%\usepackage{geometry}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -46,8 +48,6 @@
 		ilines							% Align dividing line left-aligned
 ]{scrpage2}
 
-\setlength{\topskip}{\ht\strutbox} % fixes warning of geometry
-\geometry{paper=a4paper,left=30mm,right=18mm,top=15mm,bottom=55mm}
 
 \pagestyle{scrheadings} % headers and footers
 \renewcommand*{\chapterpagestyle}{scrheadings} % header and footer on the first page of chapter
@@ -65,7 +65,6 @@
 \setlength{\headheight}{30mm} % height of header
 % broaden header beyond the text
 \setheadwidth[10pt]{textwithmarginpar}
-\setheadsepline[text]{0.4pt} % line beneath header
 
 %% Footer
 %\ifoot{\small{\thesistype\ \autor}}
@@ -73,6 +72,7 @@
 \cfoot{}
 \ofoot{\pagemark}
 
+\recalctypearea %force recalculation of page layout, after setting headers, footers and line spread
 
 %% first tests towards the usage of xetex
 %\usepackage[T1]{fontenc}

--- a/header.tex
+++ b/header.tex
@@ -20,15 +20,13 @@
 		draft=true, 				% draft=true useful during writing, set to false for final document %BUG will stop hyperref from working (bookmarks)
                 DIV=13,					%number columns for page layout calculation. The larger, the smaller margins will be. Standard for 12pt is 12
                 BCOR=10mm,				%reserved inner margin for binding
+                headinclude,				%include header into text area
 ]{scrreprt}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %% Line Spacing and Margins %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage[onehalfspacing]{setspace}
-%\usepackage{geometry}
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 
 %% Scripture and Language %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage[english]{babel}  %LANGUAGE
@@ -60,11 +58,10 @@
 %\ihead{\large{\textsc{\thesistype}}\ - \small{\autor} \\ \textit{\headmark}}
 \ihead{\textit{\headmark}}
 \chead{}
-\ohead{\pagemark}
+\ohead{}
 %\ohead{\includegraphics[scale=0.15]{\logo}}
-\setlength{\headheight}{30mm} % height of header
 % broaden header beyond the text
-\setheadwidth[10pt]{textwithmarginpar}
+\setheadwidth{textwithmarginpar}
 
 %% Footer
 %\ifoot{\small{\thesistype\ \autor}}

--- a/header.tex
+++ b/header.tex
@@ -22,6 +22,12 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
+%% Line Spacing and Margins %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage[onehalfspacing]{setspace}
+\usepackage{geometry}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
 %% Scripture and Language %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage[english]{babel}  %LANGUAGE
 %\usepackage[ngerman]{babel} %LANGUAGE
@@ -29,6 +35,44 @@
 \usepackage[ansinew]{inputenc}
 \usepackage{textcomp} % Euro-Sign etc.
 \usepackage{lmodern}
+
+%% Page Style %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\usepackage[perpage]{footmisc}
+% Customize headers and footers
+\usepackage[
+		automark,						% Create Chapter Information in Header automatically
+		headsepline,					% Dividing line under header
+%		footsepline,					% Dividing line over footer
+		ilines							% Align dividing line left-aligned
+]{scrpage2}
+
+\setlength{\topskip}{\ht\strutbox} % fixes warning of geometry
+\geometry{paper=a4paper,left=30mm,right=18mm,top=15mm,bottom=55mm}
+
+\pagestyle{scrheadings} % headers and footers
+\renewcommand*{\chapterpagestyle}{scrheadings} % header and footer on the first page of chapter
+\renewcommand{\headfont}{\normalfont} % font of the header
+
+%TODO: fancyhdr
+
+%% Header
+%\ihead{\large{\textsc{\thesistitle}}\\ \small{\thesistitle} \\[2ex] \textit{\headmark}}
+%\ihead{\large{\textsc{\thesistype}}\ - \small{\autor} \\ \textit{\headmark}}
+\ihead{\textit{\headmark}}
+\chead{}
+\ohead{\pagemark}
+%\ohead{\includegraphics[scale=0.15]{\logo}}
+\setlength{\headheight}{30mm} % height of header
+% broaden header beyond the text
+\setheadwidth[10pt]{textwithmarginpar}
+\setheadsepline[text]{0.4pt} % line beneath header
+
+%% Footer
+%\ifoot{\small{\thesistype\ \autor}}
+\ifoot{}
+\cfoot{}
+\ofoot{\pagemark}
+
 
 %% first tests towards the usage of xetex
 %\usepackage[T1]{fontenc}
@@ -103,12 +147,6 @@
 	commandchars=\|\(\), % escape character and argument delimiters for commands within the verbatim
 	commentchar=*        % comment character
 }
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-%% Line Spacing and Margins %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\usepackage{setspace}
-\usepackage{geometry}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -236,14 +274,6 @@
 \usepackage{scrhack}					% To prevent a listing Warning
 \usepackage{listings}					% Program Code
 %\usepackage{chngcntr}					% Continuous renumber the footnotes
-\usepackage[perpage]{footmisc}
-% Customize headers and footers
-\usepackage[
-		automark,						% Create Chapter Information in Header automatically
-		headsepline,					% Dividing line under header
-%		footsepline,					% Dividing line over footer
-		ilines							% Align dividing line left-aligned
-]{scrpage2}
 
 \usepackage{caption}
 	\captionsetup{justification=raggedright,format=hang,margin=30pt,font=small,labelfont=bf,labelsep=endash}
@@ -256,39 +286,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \makenomenclature
-
-
-%% Page Style %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Line Spacing 1,5
-\onehalfspacing
-%\linespread{1.5}
-
-\setlength{\topskip}{\ht\strutbox} % fixes warning of geometry
-\geometry{paper=a4paper,left=30mm,right=18mm,top=15mm,bottom=55mm}
-
-\pagestyle{scrheadings} % headers and footers
-\renewcommand*{\chapterpagestyle}{scrheadings} % header and footer on the first page of chapter
-\renewcommand{\headfont}{\normalfont} % font of the header
-
-%TODO: fancyhdr
-
-%% Header
-%\ihead{\large{\textsc{\thesistitle}}\\ \small{\thesistitle} \\[2ex] \textit{\headmark}}
-%\ihead{\large{\textsc{\thesistype}}\ - \small{\autor} \\ \textit{\headmark}}
-\ihead{\textit{\headmark}}
-\chead{}
-\ohead{\pagemark}
-%\ohead{\includegraphics[scale=0.15]{\logo}}
-\setlength{\headheight}{30mm} % height of header
-% broaden header beyond the text
-\setheadwidth[10pt]{textwithmarginpar}
-\setheadsepline[text]{0.4pt} % line beneath header
-
-%% Footer
-%\ifoot{\small{\thesistype\ \autor}}
-\ifoot{}
-\cfoot{}
-\ofoot{\pagemark}
 
 
 %% Miscellaneous %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I modified the header to create the page layout with the tools KOMA-Script provides.

This means the package geometry is not used anymore. Also there are some slight differences resulting from the switch:
- Notes on the margins now appear correct
- the foot margin is now higher (KOMA-Script uses double the height of the head margin)
- the header is included into the text area, to create a similar appearance to the original document
