### PR TITLE
Add information for package nomenclature

### DIFF
--- a/content/Nomenclature.tex
+++ b/content/Nomenclature.tex
@@ -1,3 +1,10 @@
+%Bei der Verwendung des Pakets nomenclature muss der Befehl makeindex ausgeführt werden, um das Abkürzungsverzeichnis zu aktualisieren.
+%When using the package nomenclature, you have to execute the command makeindex to update the list of abbreviations.
+%https://tex.stackexchange.com/questions/27824/using-package-nomencl
+%latex <filename>.tex
+%makeindex <filename>.nlo -s nomencl.ist -o <filename>.nls
+%latex <filename>.tex
+
 \nomenclature{UART}{Universal Asynchronous Receiver Transmitter}
 %\nomenclature{}{}
 %\nomenclature{}{}


### PR DESCRIPTION
Da nicht jede IDE bei der Verwendung des Pakets nomenclature den entsprechenden Befehl ausführt, welcher das Abkürzungsverzeichnis aktualisiert. Habe ich den Hinweis, welcher Befehl benötigt wird zu der Datei Nomenclature.tex hinzugefügt.